### PR TITLE
Added bundleSFX support. Updated readme.

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -20,6 +20,7 @@ var Builder = require('systemjs-builder');
 function compile(options) {
     options = _.assign({
         baseUrl: '.',
+        bundleSfx: false,
         bundles: [],
         config: {},
         bundleOptions: {}
@@ -27,7 +28,8 @@ function compile(options) {
 
     var files = [],
         bundlesConfig = {},
-        builder = new Builder(options.baseUrl, options.config);
+        builder = new Builder(options.baseUrl, options.config),
+        build = options.bundleSfx ? builder.buildStatic : builder.bundle;
 
     var promises = _.map(options.bundles, function(bundle) {
         if(!bundle.src) {
@@ -40,7 +42,7 @@ function compile(options) {
 
         var opts = _.assign(_.clone(options.bundleOptions), bundle.options);
 
-        return builder.bundle(bundle.src, opts)
+        return build(bundle.src, opts)
             .then(function(result) {
                 files.push(new File({
                     path: bundle.dst,

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,9 @@ arguments to ```systemjs-builder``` in following format.
 Same as ```options``` for individual bundle but specifies common options for all
 bundles.
 
+## config
+Optional, the jspm configuration file to use.
+
 ## configOverride
 Override sections of config.js. This could be useful if you want to change things
 like baseURL.
@@ -64,6 +67,15 @@ configOverride: {
     baseURL: '/foo'
 }
 ```
+
+## baseUrl
+The jspm base URL, as normally specified in your ```package.json``` under ```config.jspm.directories.baseURL```. Defaults to ```'.'```.
+
+## bundleSfx
+Create a single file executable, including all necessary dependencies and systemjs. Defaults to ```false```.
+
+> See the [jspm documentation](https://github.com/jspm/jspm-cli/blob/master/docs/production-workflows.md#creating-a-self-executing-bundle)
+  for more information.
 
 # Example
 

--- a/spec/compileSpec.js
+++ b/spec/compileSpec.js
@@ -1,8 +1,13 @@
 var _ = require('lodash');
 var proxyquire = require('proxyquire');
 
-var builder = jasmine.createSpyObj('bundle', ['config', 'bundle']);
+var builder = jasmine.createSpyObj('bundle', ['config', 'bundle', 'buildStatic']);
 builder.bundle.and.returnValue(Promise.resolve({
+    source: 'source',
+    sourceMap: 'source-map',
+    modules: []
+}));
+builder.buildStatic.and.returnValue(Promise.resolve({
     source: 'source',
     sourceMap: 'source-map',
     modules: []
@@ -56,6 +61,19 @@ describe('compile', function() {
         })
         .catch(function(e) {
             done.fail(e);
+        });
+    });
+});
+
+describe('options', function() {
+    it('should call buildStatic when the bundleSfx option is specified', function(done) {
+        compile({
+            bundles: [ { src: 'a', dst: 'b' } ],
+            bundleSfx: true
+        })
+        .then(function() {
+            expect(builder.buildStatic).toHaveBeenCalled();
+            done();
         });
     });
 });


### PR DESCRIPTION
This PR adds support for creating a single file executable. See here: https://github.com/jspm/jspm-cli/blob/master/docs/production-workflows.md#creating-a-self-executing-bundle
