### PR TITLE
Fixed issue with build function losing identity

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -29,7 +29,7 @@ function compile(options) {
     var files = [],
         bundlesConfig = {},
         builder = new Builder(options.baseUrl, options.config),
-        build = options.bundleSfx ? builder.buildStatic : builder.bundle;
+        build = _.bind(options.bundleSfx ? builder.buildStatic : builder.bundle, builder);
 
     var promises = _.map(options.bundles, function(bundle) {
         if(!bundle.src) {


### PR DESCRIPTION
My previous change caused the build function to be called without any identity (`this` object). This fixes the issue, ensuring that the function is called with the correct identity.
