### PR TITLE
Use stable stringify and sort bundle lists

### DIFF
--- a/lib/buildConfig.js
+++ b/lib/buildConfig.js
@@ -1,7 +1,13 @@
 var File = require('vinyl');
+var stringify = require('json-stable-stringify');
 
 function buildConfig(config) {
-    var configStr = JSON.stringify(config, null, 4);    
+    if (config.bundles) {
+        for (var b in config.bundles) {
+            config.bundles[b].sort();
+        }
+    }
+    var configStr = stringify(config, { space: '    ' });
     return new File({
         path: 'config.js',
         contents: new Buffer('System.config(' + configStr + ');')

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "gulp": "^3.9.0",
+    "json-stable-stringify": "^1.0.1",
     "lodash": "^3.10.1",
     "systemjs-builder": "^0.14.6",
     "through2": "^2.0.0",

--- a/spec/buildConfigSpec.js
+++ b/spec/buildConfigSpec.js
@@ -6,4 +6,12 @@ describe('buildConfig', function() {
         var f = buildConfig( config );
         expect(f.contents.toString()).toBe('System.config(' + JSON.stringify(config, null, 4) + ');');
     });
+    
+    it('should create a stably-ordered config file', function() {
+        var config1 = { a: 'b', bundles: { 'bundle.js': ['something.js', 'another.js']} };
+        var config2 = { bundles: { 'bundle.js': ['another.js', 'something.js']}, a: 'b' };
+        var f1 = buildConfig( config1 );
+        var f2 = buildConfig( config2 );
+        expect(f1.contents.toString()).toBe(f2.contents.toString());
+    });
 });


### PR DESCRIPTION
This change fixes #16 for me. I think it'd be nice if system.js sorted the bundle arrays, but not a huge deal.
