### PR TITLE
Fix Cannot see src/ files using bundles issue #23

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -47,7 +47,7 @@ function compile(options) {
 
                 if(opts.sourceMaps) {
                     var mapFileName = bundle.dst + '.map';
-                    source = source + '\n//# sourceMappingUrl=' + mapFileName;
+                    source = source + '\n//# sourceMappingURL=' + mapFileName;
 
                     files.push(new File({
                         path: bundle.dst + '.map',

--- a/spec/compileSpec.js
+++ b/spec/compileSpec.js
@@ -125,7 +125,7 @@ describe('source maps on', function() {
             });
 
             var content = source.contents.toString();
-            expect(content).toBe('source\n//# sourceMappingUrl=b.map');
+            expect(content).toBe('source\n//# sourceMappingURL=b.map');
             done();
         })
         .catch(function(e) {


### PR DESCRIPTION
Fixing typo: "Url" should be "URL" in generated source mapping line in bundled js, i.e.:
`//# sourceMappingUrl=app-bundle.js.map`

should be,

`//# sourceMappingURL=app-bundle.js.map`

Thank you.
